### PR TITLE
Remove node-fetch and use built-in fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "cors": "^2.8.5",
-    "node-fetch": "^3.3.2"
+    "cors": "^2.8.5"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -19,8 +19,7 @@ app.post('/api/analyze', async (req, res) => {
 
         const domain = new URL(url).hostname;
 
-        // Import fetch for Node.js
-        const fetch = (await import('node-fetch')).default;
+        // fetch זמין ב-Node.js 18+
 
         const response = await fetch("https://api.anthropic.com/v1/messages", {
             method: "POST",


### PR DESCRIPTION
## Summary
- remove `node-fetch` from dependencies and update Node engine to `>=18`
- remove dynamic import of `node-fetch` and note that fetch is built-in

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node --version`
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68838ef3651c8332aef5247b328be57e